### PR TITLE
Throw API errors on Comment.delete()

### DIFF
--- a/ifunny/objects/_main_app.py
+++ b/ifunny/objects/_main_app.py
@@ -1592,7 +1592,10 @@ class Comment(mixin.ObjectMixin):
         response = requests.delete(f"{self._absolute_url}/{self.id}",
                                    headers = self.headers)
 
-        return self
+        if response.status_code != 200:
+            raise exceptions.BadAPIResponse(f"{response.url}, {response.text}")
+
+        return self.fresh
 
     def smile(self):
         """

--- a/ifunny/objects/_main_app.py
+++ b/ifunny/objects/_main_app.py
@@ -1595,7 +1595,7 @@ class Comment(mixin.ObjectMixin):
         if response.status_code != 200:
             raise exceptions.BadAPIResponse(f"{response.url}, {response.text}")
 
-        return self.fresh
+        return self
 
     def smile(self):
         """

--- a/ifunny/objects/_main_app.py
+++ b/ifunny/objects/_main_app.py
@@ -1584,15 +1584,20 @@ class Comment(mixin.ObjectMixin):
         """
         Delete a comment
 
-        :returns: self
+        :raises: RateLimit, BadAPIResponse
 
+        :returns: self
         :rtype: Comment
         """
 
         response = requests.delete(f"{self._absolute_url}/{self.id}",
                                    headers = self.headers)
 
-        if response.status_code != 200:
+        if response.status_code == 429:
+            raise exceptions.RateLimit(
+                f"Failed to delete the comment. Are you deleting comments too fast?"
+            )
+        elif response.status_code != 200:
             raise exceptions.BadAPIResponse(f"{response.url}, {response.text}")
 
         return self


### PR DESCRIPTION
Added code to throw errors if API returns a non-200 status code. Also changed return value to `self.fresh` to properly set update flag when comment is deleted. Fixes #7